### PR TITLE
Negamax, Iterative deepening, timers!

### DIFF
--- a/team-00/src/main/java/ubc/cosc322/ActionFactory.java
+++ b/team-00/src/main/java/ubc/cosc322/ActionFactory.java
@@ -6,7 +6,6 @@ public class ActionFactory {
 
 
     public static ArrayList<Action> getActions(Board board, int player){
-        // System.out.println("Generating actions.. for: " + player);
         ArrayList<Action> actions = new ArrayList<>();
 
         for (int i = 0; i < board.getBoardSize(); i++){

--- a/team-00/src/main/java/ubc/cosc322/COSC322Test.java
+++ b/team-00/src/main/java/ubc/cosc322/COSC322Test.java
@@ -33,7 +33,7 @@ public class COSC322Test extends GamePlayer {
 	private Board board;
 	private int player;
 	private Action action;
-	// private static TestClass testClass;
+	private static TestClass testClass;
 	private boolean isBlack;
    
 
@@ -46,7 +46,7 @@ public class COSC322Test extends GamePlayer {
 
 		GamePlayer player;
         GamePlayer player2;
-		// testClass = new TestClass();
+		testClass = new TestClass();
 		
 		// COSC322Test player = new COSC322Test(args[0], args[1]);
 
@@ -117,6 +117,7 @@ public class COSC322Test extends GamePlayer {
 				if (isBlack){
 					System.out.print("Hello Black");
 				    makeMinMaxMove();
+                    // makeRandomMove();
 
                     // display the board after opening move
                     System.out.println("BOARD AFTER OPENING BLACK MOVE:");
@@ -157,15 +158,15 @@ public class COSC322Test extends GamePlayer {
                 System.out.println("new board:");
                 System.out.println(board.boardToString());
 
-                // test the opponent move against the validator
-                // Action opponentAction = testClass.findMove(oldBoard, board);
-				// System.out.println("Opponent move legal? " + testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard));
+               	// test the opponent move against the validator
+                Action opponentAction = testClass.findMove(oldBoard, board);
+				System.out.println("Opponent move legal? " + testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard));
 
-                // // shut down the game if opponent makes an illegal move
-				// if (!testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard)){
-                // System.out.println("Opponent has made an illegal move!");
-                //     System.exit(0);
-                // }
+                // shut down the game if opponent makes an illegal move
+				if (!testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard)){
+                System.out.println("Opponent has made an illegal move!");
+                    System.exit(0);
+                }
 		
                 // update the gui if all checks pass
 				getGameGUI().updateGameState(msgDetails);
@@ -173,7 +174,7 @@ public class COSC322Test extends GamePlayer {
                 // make our move
                 // currently set up to play against white making random moves
 				if (isBlack) {
-					// makeRandomMove();
+					//makeRandomMove();
 					makeMinMaxMove();
 				} else {
 					// makeRandomMove();
@@ -188,7 +189,7 @@ public class COSC322Test extends GamePlayer {
                 // end game condition checking
 				if (ActionFactory.getActions(board, player == Board.BLACK_QUEEN ? Board.WHITE_QUEEN : Board.BLACK_QUEEN)
 						.size() == 0) {
-					System.out.println("We(" + player + ") won");
+					System.out.println("" + player + " won");
                     //System.exit(0);
 				}
 				break;
@@ -206,13 +207,13 @@ public class COSC322Test extends GamePlayer {
 	private void makeRandomMove() {
 		System.out.println("making move for black? " + isBlack);
 		ArrayList<Action> actions = ActionFactory.getActions(board, isBlack ? Board.BLACK_QUEEN : Board.WHITE_QUEEN);
-
-		System.out.println("WE made the actions");
-		Action move = actions.get((int) (Math.random() * actions.size()));
         if (actions.size() == 0){
             System.out.println("We("+player+") are out of moves, we lost!! :( :( :( ");
             // System.exit(0);
         }
+
+		System.out.println("WE made the actions");
+		Action move = actions.get((int) (Math.random() * actions.size()));
 
 		System.out.println("About to send random move");
 		getGameClient().sendMoveMessage(move.toServerResponse());

--- a/team-00/src/main/java/ubc/cosc322/COSC322Test.java
+++ b/team-00/src/main/java/ubc/cosc322/COSC322Test.java
@@ -33,7 +33,7 @@ public class COSC322Test extends GamePlayer {
 	private Board board;
 	private int player;
 	private Action action;
-	private static TestClass testClass;
+	// private static TestClass testClass;
 	private boolean isBlack;
    
 
@@ -46,7 +46,7 @@ public class COSC322Test extends GamePlayer {
 
 		GamePlayer player;
         GamePlayer player2;
-		testClass = new TestClass();
+		// testClass = new TestClass();
 		
 		// COSC322Test player = new COSC322Test(args[0], args[1]);
 
@@ -123,7 +123,6 @@ public class COSC322Test extends GamePlayer {
 				    System.out.println(board.boardToString());
                 }
 
-				System.out.println(board.boardToString());
 				break;
 			case GameMessage.GAME_STATE_BOARD:
                 // this is the opening state of the game of the game
@@ -159,14 +158,14 @@ public class COSC322Test extends GamePlayer {
                 System.out.println(board.boardToString());
 
                 // test the opponent move against the validator
-                Action opponentAction = testClass.findMove(oldBoard, board);
-				System.out.println("Opponent move legal? " + testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard));
+                // Action opponentAction = testClass.findMove(oldBoard, board);
+				// System.out.println("Opponent move legal? " + testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard));
 
-                // shut down the game if opponent makes an illegal move
-				if (!testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard)){
-                System.out.println("Opponent has made an illegal move!");
-                    System.exit(0);
-                }
+                // // shut down the game if opponent makes an illegal move
+				// if (!testClass.checkIfMoveValid(opponentAction, getOpponent(player), oldBoard)){
+                // System.out.println("Opponent has made an illegal move!");
+                //     System.exit(0);
+                // }
 		
                 // update the gui if all checks pass
 				getGameGUI().updateGameState(msgDetails);
@@ -177,8 +176,9 @@ public class COSC322Test extends GamePlayer {
 					// makeRandomMove();
 					makeMinMaxMove();
 				} else {
-					makeRandomMove();
+					// makeRandomMove();
 					// makeMinMaxMove();
+                    makeNegamaxMove();
 				}
 
 				// Additional visualization to ensure board is as expected
@@ -211,7 +211,7 @@ public class COSC322Test extends GamePlayer {
 		Action move = actions.get((int) (Math.random() * actions.size()));
         if (actions.size() == 0){
             System.out.println("We("+player+") are out of moves, we lost!! :( :( :( ");
-            System.exit(0);
+            // System.exit(0);
         }
 
 		System.out.println("About to send random move");
@@ -222,22 +222,84 @@ public class COSC322Test extends GamePlayer {
 	}
 
 	private void makeMinMaxMove() {
-		// will eventually use iterative deepening on a timer, tree will be smaller as
-		// game progresses
-		int depth = 1;
-		int player = isBlack ? Board.BLACK_QUEEN : Board.WHITE_QUEEN;
-		Action bestAction = MinMax.findBestAction(board, depth, player, 1);
-        if (bestAction == null){
-            System.out.println("We("+player+") are out of moves, we lost!! :( :( :( ");
-            System.exit(0);
+        // Initialize the best action with null
+        Action bestAction = null;
+    
+        // Start with a depth of 1
+        int depth = 1;
+        int player = isBlack ? Board.BLACK_QUEEN : Board.WHITE_QUEEN;
+    
+        // Get the current time
+        long startTime = System.currentTimeMillis();
+        long timeLimit = 2000; // 30 seconds
+    
+        // Iterate until time limit is reached
+        while (System.currentTimeMillis() - startTime < 2000) { // 30 seconds
+    
+            // Perform Minimax search with the current depth
+            Action currentBestAction = MinMax.findBestAction(board, depth, player, 1, startTime, timeLimit);
+            if (currentBestAction == null) {
+                System.out.println("We("+player+") are out of MinMax moves, we lost!! :( :( :( ");
+                // System.exit(0);
+            }
+    
+            // Update the best action found so far
+            bestAction = currentBestAction;
+    
+            // Increment the depth for the next iteration
+            depth++;
         }
-
-		System.out.println("making min max move for black? " + isBlack);
-		getGameClient().sendMoveMessage(bestAction.toServerResponse());
-		getGameGUI().updateGameState(bestAction.toServerResponse());
-
-		board.updateBoardState(bestAction);
-	}
+    
+        // Send the best action found so far
+        if (bestAction != null) {
+            System.out.println("making min max move for black? " + isBlack);
+            getGameClient().sendMoveMessage(bestAction.toServerResponse());
+            getGameGUI().updateGameState(bestAction.toServerResponse());
+            board.updateBoardState(bestAction);
+        } else {
+            System.out.println("No valid move found within the time limit.");
+        }
+    }
+    
+    private void makeNegamaxMove() {
+        // Initialize the best action with null
+        Action bestAction = null;
+    
+        // Start with a depth of 1
+        int depth = 1;
+        int player = isBlack ? Board.BLACK_QUEEN : Board.WHITE_QUEEN;
+    
+        // Get the current time
+        long startTime = System.currentTimeMillis();
+        long timeLimit = 2000; // 30 seconds
+    
+        // Iterate until time limit is reached
+        while (System.currentTimeMillis() - startTime < 2000) { // 30 seconds
+    
+            // Perform Negamax search with the current depth
+            Action currentBestAction = Negamax.findBestAction(board, depth, player, 1, startTime, timeLimit);
+            if (currentBestAction == null) {
+                System.out.println("We("+player+") are out of Negamax moves, we lost!! :( :( :( ");
+                // System.exit(0);
+            }
+    
+            // Update the best action found so far
+            bestAction = currentBestAction;
+    
+            // Increment the depth for the next iteration
+            depth++;
+        }
+    
+        // Send the best action found so far
+        if (bestAction != null) {
+            System.out.println("making negamax move for black? " + isBlack);
+            getGameClient().sendMoveMessage(bestAction.toServerResponse());
+            getGameGUI().updateGameState(bestAction.toServerResponse());
+            board.updateBoardState(bestAction);
+        } else {
+            System.out.println("No valid move found within the time limit.");
+        }
+    }
 
 	@Override
 	public String userName() {

--- a/team-00/src/main/java/ubc/cosc322/Negamax.java
+++ b/team-00/src/main/java/ubc/cosc322/Negamax.java
@@ -1,0 +1,100 @@
+package ubc.cosc322;
+import java.util.*;
+
+public class Negamax {
+    public int evaluation;
+    public Action bestAction;
+    private int nodeCount = 0;
+
+    public Negamax(int evaluation, Action bestAction) {
+        this.evaluation = evaluation;
+        this.bestAction = bestAction;
+    }
+
+    public static Action findBestAction(Board board, int depth, int player, int heuristic, long startTime, long timeLimit) {
+        int alpha = Integer.MIN_VALUE;
+        int beta = Integer.MAX_VALUE;
+
+        Negamax result = negamaxSearch(board, depth, alpha, beta, player, heuristic, startTime, timeLimit);
+
+        Action bestAction = result.bestAction;
+
+        return bestAction;
+    }
+
+    private static Negamax negamaxSearch(Board board, int depth, int alpha, int beta, int player, int heuristic, long startTime,long timeLimit) {
+        List<Action> legalActions = ActionFactory.getActions(board, player);
+        if (depth == 0 || legalActions.isEmpty()) {
+            return new Negamax(evaluate(board, player, heuristic), null);
+        }
+
+        Action bestAction = null;
+        int maxEval = Integer.MIN_VALUE;
+
+        for (Action action : legalActions) {
+            Board nextBoard = new Board(board, action);
+            if (System.currentTimeMillis() - startTime >= timeLimit) {
+                System.out.println("Time's up! Search interrupted.");
+                return new Negamax(maxEval, bestAction); // Return the best action found so far
+            }
+            int eval = -negamaxSearch(nextBoard, depth - 1, -beta, -alpha, getOpponent(player), heuristic, startTime, timeLimit).evaluation;
+            if (eval > maxEval) {
+                maxEval = eval;
+                bestAction = action;
+            }
+            alpha = Math.max(alpha, eval);
+            if (beta <= alpha) {
+                break;
+            }
+        }
+        return new Negamax(maxEval, bestAction);
+    }
+
+    private static int evaluate(Board board, int player, int heuristic) {
+        switch (heuristic) {
+            case 1:
+                return mobilityHeuristic(board, player);
+            case 2:
+                return territoryHeuristic(board, player);
+            default:
+                return 0; // Default evaluation if heuristic not specified
+        }
+    }
+
+    private static int mobilityHeuristic(Board board, int player) {
+        int mobilityScore = ActionFactory.getActions(board, player).size() - ActionFactory.getActions(board, getOpponent(player)).size();
+        return mobilityScore;
+    }
+
+    private static int territoryHeuristic(Board board, int player) {
+        int playerTerritory = 0;
+        for (int i = 0; i < board.getBoardSize(); i++) {
+            for (int j = 0; j < board.getBoardSize(); j++) {
+                ArrayList<Action> playerActions = ActionFactory.getActions(board, player);
+                ArrayList<Action> opponentActions = ActionFactory.getActions(board, getOpponent(player));
+                int playerSquare = 0;
+                int opponentSquare = 0;
+                for (Action action : playerActions) {
+                    if (action.getQueenMove().getEndCol() == i && action.getQueenMove().getEndRow() == j) {
+                        playerSquare++;
+                    }
+                }
+                for (Action action : opponentActions) {
+                    if (action.getQueenMove().getEndCol() == i && action.getQueenMove().getEndRow() == j) {
+                        opponentSquare++;
+                    }
+                }
+                int squareOwner = playerSquare - opponentSquare;
+                if (squareOwner < 0)
+                    playerTerritory--;
+                if (squareOwner > 0)
+                    playerTerritory++;
+            }
+        }
+        return playerTerritory;
+    }
+
+    private static int getOpponent(int player) {
+        return player == 1 ? 2 : 1;
+    }
+}

--- a/team-00/src/main/java/ubc/cosc322/minmax.java
+++ b/team-00/src/main/java/ubc/cosc322/minmax.java
@@ -11,25 +11,24 @@ public class MinMax {
         this.bestAction = bestAction;
     }
 
-    public static Action findBestAction(Board board, int depth, int player, int heuristic) {
+    public static Action findBestAction(Board board, int depth, int player, int heuristic, long startTime, long timeLimit) {
         int alpha = Integer.MIN_VALUE;
         int beta = Integer.MAX_VALUE;
         int maximizingPlayer = player;
 
-        MinMax result = minMaxSearch(board, depth, alpha, beta, maximizingPlayer, player, heuristic);
+        MinMax result = minMaxSearch(board, depth, alpha, beta, maximizingPlayer, player, heuristic, startTime, timeLimit);
 
         Action bestAction = result.bestAction;
 
-        // System.out.println(new MinMax(0,bestAction).getNodeCount());
 
         return bestAction;
     }
 
-    private static MinMax minMaxSearch(Board board, int depth, int alpha, int beta, int maximizingPlayer, int currentPlayer, int heuristic) {
+    private static MinMax minMaxSearch(Board board, int depth, int alpha, int beta, int maximizingPlayer, int currentPlayer, int heuristic, long startTime, long timeLimit) {
         // setNodeCount(getNodeCount()++);
         List<Action> legalActions = ActionFactory.getActions(board, currentPlayer);
         if (depth == 0 || legalActions.isEmpty()) {
-            return new MinMax (evaluate(board, maximizingPlayer, heuristic ), null);
+            return new MinMax (evaluate(board, maximizingPlayer, heuristic), null);
         }
 
         Action bestAction = null;
@@ -37,10 +36,12 @@ public class MinMax {
         if (currentPlayer == maximizingPlayer) {
             int maxEval = Integer.MIN_VALUE;
             for (Action action : legalActions) {
+                if (System.currentTimeMillis() - startTime >= timeLimit) {
+                    System.out.println("Time's up! Search interrupted.");
+                    return new MinMax(maxEval, bestAction); // Return the best action found so far
+                }
                 Board nextBoard = new Board(board, action);
-                // System.out.println(nextBoard.boardToString());
-                // System.out.println(board.boardToString());
-                int eval = minMaxSearch(nextBoard, depth - 1, alpha, beta, maximizingPlayer, getOpponent(currentPlayer), heuristic).evaluation;
+                int eval = minMaxSearch(nextBoard, depth - 1, alpha, beta, maximizingPlayer, getOpponent(currentPlayer), heuristic, startTime, timeLimit).evaluation;
                 if (eval > maxEval) {
                     maxEval = eval;
                     bestAction = action;
@@ -54,10 +55,12 @@ public class MinMax {
         } else {
             int minEval = Integer.MAX_VALUE;
             for (Action action : legalActions) {
+                if (System.currentTimeMillis() - startTime >= timeLimit) {
+                    System.out.println("Time's up! Search interrupted.");
+                    return new MinMax(minEval, bestAction); // Return the best action found so far
+                }
                 Board nextBoard = new Board(board, action);
-                // System.out.println(nextBoard.boardToString());
-                // System.out.println(board.boardToString());
-                int eval = minMaxSearch(nextBoard, depth - 1, alpha, beta, maximizingPlayer, getOpponent(currentPlayer), heuristic).evaluation;
+                int eval = minMaxSearch(nextBoard, depth - 1, alpha, beta, maximizingPlayer, getOpponent(currentPlayer), heuristic, startTime, timeLimit).evaluation;
                 if (eval < minEval) {
                     minEval = eval;
                     bestAction = action;
@@ -67,7 +70,6 @@ public class MinMax {
                     break;
                 }
             }
-            System.out.println(minEval);
             return new MinMax(minEval, bestAction);
         }
     }
@@ -93,7 +95,6 @@ public class MinMax {
     
     private static int mobilityHeuristic(Board board, byte player){
         int mobilityScore = ActionFactory.getActions(board, player).size() - ActionFactory.getActions(board, getOpponent(player)).size();
-        // System.out.println("Mobility score for player " + player + ": " + mobilityScore);
         return mobilityScore;
     }
 
@@ -101,7 +102,6 @@ public class MinMax {
         byte playerTerritory = 0;
         for(int i = 0; i < board.getBoardSize(); i++){
             for(int j = 0; j < board.getBoardSize(); j++){
-                // System.out.println(ActionFactory.getActions(board, player).toString());
                 ArrayList<Action> playerActions =  ActionFactory.getActions(board, player);
                 ArrayList<Action> opponentActions =  ActionFactory.getActions(board, getOpponent(player));
 


### PR DESCRIPTION
# Overview
This PR adds the Negamax algorithm, iterative deepening, and timed moves

## Details
- [x] `Negamax` simplifies code, may increase simplicity to parallelize. Does not improve complexity (as previously thought)
- [x] `Iterative deepening` - increases depth of search. Refactors search methods with timers
- [x] In game `move timer`, forces best action on time basis. Couples with iterative deepening
- [x] Still incorporates `move validator` - does not seem computationally expensive
- [x] `Prints` game results but does not shut down game `System.exit()` left out for now to keep board visual.

Current implementation is set up to have two AI players. We can choose `random moves`, `negamax`, `minmax`, and our choice of `heursitic`.

## Current Findings
- `Negamax` seems to outperform `minmax`, maybe just random at this point, `minmax` still wins games
- Given a fixed amount of time, `mobility` heuristic seems to outperform `territory`, maybe `mobility` is faster and hence get further down game tree to make better decision